### PR TITLE
feat(api): Search Advocates by Query Params

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -1,0 +1,11 @@
+If I had more time on this Search Params PR, I would:
+- Make sure each field on the advocates is search-able. Currently, I just wired up the first & last names.
+- I may explore using Tanstack's React Query as well.
+- Add pagination / test with more advocates.
+- Add sorting.
+- Show a loading state / skeleton loaders.
+- Add a "No results Found" state.
+- Adding form validation.
+- DRYing up and simplifying the way I'm using the query params in the API call.  I only used 2 params but it got a bit ugly quick.  With more time, that could get streamlined and cleaned up a bit.
+- Add tests.
+- As always, add more docs.

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,29 @@
 import db from "../../../db";
 import { advocates } from "../../../db/schema";
 import { advocateData } from "../../../db/seed/advocates";
+import { NextRequest } from 'next/server';
+import { first, isNil } from "lodash";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   // Uncomment this line to use a database
   // const data = await db.select().from(advocates);
+  const data = await advocateData;
+  let dataToReturn = data;
+  // console.log('In route.ts, this is data?.length: ', data?.length);
 
-  const data = advocateData;
+  const firstName = request?.nextUrl?.searchParams?.get('firstName');
+  const lastName = request?.nextUrl?.searchParams?.get('lastName');
 
-  return Response.json({ data });
+  const isFirstNameQueryPresent = !isNil(firstName);
+
+  // console.log('In route.ts, this is firstName: ', firstName);
+  // console.log('In route.ts, this is lastName: ', lastName);
+  // console.log('isNil(lastName): ', isNil(lastName));
+
+  if (isFirstNameQueryPresent) {
+    dataToReturn = data?.filter((advocate) => advocate?.firstName === firstName);
+  }
+
+  console.log('dataToReturn?.length: ', dataToReturn?.length);
+  return Response.json({ data: dataToReturn });
 }

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,29 +1,39 @@
-import db from "../../../db";
-import { advocates } from "../../../db/schema";
+// import db from "../../../db";
+// import { advocates } from "../../../db/schema";
 import { advocateData } from "../../../db/seed/advocates";
 import { NextRequest } from 'next/server';
-import { first, isNil } from "lodash";
+import { isEmpty, isNil } from "lodash";
 
 export async function GET(request: NextRequest) {
   // Uncomment this line to use a database
   // const data = await db.select().from(advocates);
-  const data = await advocateData;
+
+  let data = await advocateData;
   let dataToReturn = data;
-  // console.log('In route.ts, this is data?.length: ', data?.length);
+  let firstNameResults: typeof advocateData = [];
+  let lastNameResults: typeof advocateData = [];
 
   const firstName = request?.nextUrl?.searchParams?.get('firstName');
   const lastName = request?.nextUrl?.searchParams?.get('lastName');
 
-  const isFirstNameQueryPresent = !isNil(firstName);
+  const isFirstNameQueryPresent = !isNil(firstName) && !isEmpty(firstName);
+  const isLastNameQueryPresent = !isNil(lastName) && !isEmpty(lastName);
 
-  // console.log('In route.ts, this is firstName: ', firstName);
-  // console.log('In route.ts, this is lastName: ', lastName);
-  // console.log('isNil(lastName): ', isNil(lastName));
+  const hasFilters = isFirstNameQueryPresent || isLastNameQueryPresent;
 
+  // TODO: Search by all params and DRY this up:
   if (isFirstNameQueryPresent) {
-    dataToReturn = data?.filter((advocate) => advocate?.firstName === firstName);
+    firstNameResults = data?.filter((advocate) => advocate?.firstName === firstName);
+  }
+  if (isLastNameQueryPresent) {
+    lastNameResults = data?.filter((advocate) => advocate?.lastName === lastName);
   }
 
-  console.log('dataToReturn?.length: ', dataToReturn?.length);
+  if (hasFilters) {
+    const concatArr = firstNameResults.concat(lastNameResults);
+    const result = concatArr.filter((item, idx) => concatArr.indexOf(item) === idx);
+    dataToReturn = result;
+  }
+
   return Response.json({ data: dataToReturn });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,19 @@
 import AdvocatesTable from "@/components/AdvocatesTable";
+import objectToUrlParams from "@/utils/urlHelpers";
 
-export default async function Home() {
+export default async function Home({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+}) {
+  // console.log('In page.tsx, this is searchParams: ', searchParams);
+  const params = await searchParams;
+  console.log('In page.tsx, this is params: ', params);
+  const filters = await objectToUrlParams(params);
+  console.log('In page.tsx, this is filters: ', filters);
 
-  const data = await fetch("http://localhost:3000/api/advocates");
-  const advocates = data.json();
+  const data = await fetch(`http://localhost:3000/api/advocates?${filters}`);
+  const advocates = data?.json();
 
   return (
     <main style={{ margin: "24px" }}>

--- a/src/components/AdvocatesSearch/index.tsx
+++ b/src/components/AdvocatesSearch/index.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { parse } from "path";
+import { useState, useEffect } from "react";
+import type { ChangeEvent } from "react";
+import { kebabCase } from "lodash";
+import { usePathname, useRouter } from 'next/navigation'
+
+type paramsTypes = {
+  [key: string]: string | string[] | undefined | FormDataEntryValue;
+};
+
+export default function AdvocatesSearch() {
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+
+  const pathname = usePathname();
+  const router = useRouter();
+
+  function search(formData: FormData) {
+    const params = [];
+    for (const pair of formData.entries()) {
+      console.log('In index.tsx, this is pair: ', pair);
+      params.push(pair);
+    }
+    // @ts-expect-error
+    const queryString = new URLSearchParams(params).toString();
+
+    router.push(`${pathname}?${queryString}`);
+  }
+
+  return (
+    <form action={search}>
+      <input onChange={(e) => setFirstName(e?.target?.value)} value={firstName} name="firstName" />
+      <input onChange={(e) => setLastName(e?.target?.value)} value={lastName} name="lastName" />
+      <button>Search!</button>
+    </form>
+  )
+
+};

--- a/src/components/AdvocatesSearch/index.tsx
+++ b/src/components/AdvocatesSearch/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from "react";
-import { usePathname, useRouter } from 'next/navigation'
+import { useState, useEffect } from "react";
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 type paramsTypes = {
   [key: string]: string | string[] | undefined | FormDataEntryValue;
@@ -12,12 +12,23 @@ export default function AdvocatesSearch() {
   const [lastName, setLastName] = useState('');
 
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const router = useRouter();
+
+  useEffect(() => {
+    const initialFirstName = searchParams?.get('firstName');
+    const initialLastName = searchParams?.get('lastName');
+    if (typeof initialFirstName === 'string') {
+      setFirstName(initialFirstName);
+    }
+    if (typeof initialLastName === 'string') {
+      setLastName(initialLastName);
+    }
+  }, [searchParams]);
 
   const search = (formData: FormData) => {
     const params = [];
     for (const pair of formData.entries()) {
-      console.log('In index.tsx, this is pair: ', pair);
       params.push(pair);
     }
     // @ts-expect-error
@@ -35,7 +46,7 @@ export default function AdvocatesSearch() {
     <form action={search}>
       <input onChange={(e) => setFirstName(e?.target?.value)} value={firstName} name="firstName" />
       <input onChange={(e) => setLastName(e?.target?.value)} value={lastName} name="lastName" />
-      <button>Search!</button>
+      <button>Search</button>
     </form>
     <button type="button" onClick={clearSearch}>Clear Search</button>
     </div>

--- a/src/components/AdvocatesSearch/index.tsx
+++ b/src/components/AdvocatesSearch/index.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import { parse } from "path";
-import { useState, useEffect } from "react";
-import type { ChangeEvent } from "react";
-import { kebabCase } from "lodash";
+import { useState } from "react";
 import { usePathname, useRouter } from 'next/navigation'
 
 type paramsTypes = {
@@ -17,7 +14,7 @@ export default function AdvocatesSearch() {
   const pathname = usePathname();
   const router = useRouter();
 
-  function search(formData: FormData) {
+  const search = (formData: FormData) => {
     const params = [];
     for (const pair of formData.entries()) {
       console.log('In index.tsx, this is pair: ', pair);
@@ -29,12 +26,19 @@ export default function AdvocatesSearch() {
     router.push(`${pathname}?${queryString}`);
   }
 
+  const clearSearch = () => {
+    router.push(pathname);
+  }
+
   return (
+    <div className="form-wrapper">
     <form action={search}>
       <input onChange={(e) => setFirstName(e?.target?.value)} value={firstName} name="firstName" />
       <input onChange={(e) => setLastName(e?.target?.value)} value={lastName} name="lastName" />
       <button>Search!</button>
     </form>
+    <button type="button" onClick={clearSearch}>Clear Search</button>
+    </div>
   )
 
 };

--- a/src/components/AdvocatesTable/index.tsx
+++ b/src/components/AdvocatesTable/index.tsx
@@ -6,7 +6,7 @@ import type { ChangeEvent } from "react";
 import { kebabCase } from "lodash";
 
 export default function AdvocatesTable(data) {
-  console.log('In AdvocatesTable.tsx, this is data?.data: ', JSON.parse(data?.data?.value));
+  // console.log('In AdvocatesTable.tsx, this is data?.data: ', JSON.parse(data?.data?.value));
   const [advocates, setAdvocates] = useState([]);
   console.log('In AdvocatesTable.tsx, this is advocates: ', advocates);
   const [filteredAdvocates, setFilteredAdvocates] = useState([]);

--- a/src/components/AdvocatesTable/index.tsx
+++ b/src/components/AdvocatesTable/index.tsx
@@ -1,61 +1,18 @@
 'use client';
 
-import { parse } from "path";
 import { useState, useEffect } from "react";
-import type { ChangeEvent } from "react";
 import { kebabCase } from "lodash";
 import AdvocatesSearch from "../AdvocatesSearch";
 
+// @ts-expect-error
 export default function AdvocatesTable(data) {
-  // console.log('In AdvocatesTable.tsx, this is data?.data: ', JSON.parse(data?.data?.value));
   const [advocates, setAdvocates] = useState([]);
-  console.log('In AdvocatesTable.tsx, this is advocates: ', advocates);
-  const [filteredAdvocates, setFilteredAdvocates] = useState([]);
-  const [searchTerm, setSearchTerm] = useState<string>("");
 
   useEffect(() => {
     const parsedData = JSON.parse(data?.data?.value)?.data;
-    console.log('In useEffect, this is parsedData: ', parsedData);
     
     setAdvocates(parsedData)
-  }, [data]);
-
-
-  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
-    // const searchTerm = e.target.value;
-    setSearchTerm(e.target.value)
-
-    // document.getElementById("search-term").innerHTML = searchTerm;
-
-    // console.log("filtering advocates...");
-    // const filteredAdvocates = advocates.filter((advocate) => {
-    //   return (
-    //     advocate.firstName.includes(searchTerm) ||
-    //     advocate.lastName.includes(searchTerm) ||
-    //     advocate.city.includes(searchTerm) ||
-    //     advocate.degree.includes(searchTerm) ||
-    //     advocate.specialties.includes(searchTerm) ||
-    //     advocate.yearsOfExperience.includes(searchTerm)
-    //   );
-    // });
-
-    // setFilteredAdvocates(filteredAdvocates);
-  };
-
-  const onClick = () => {
-    const filteredAdvocates = advocates.filter((advocate) => {
-      return (
-        advocate?.firstName?.includes(searchTerm) ||
-        advocate?.lastName?.includes(searchTerm) ||
-        advocate?.city?.includes(searchTerm) ||
-        advocate?.degree?.includes(searchTerm) ||
-        advocate?.specialties?.includes(searchTerm) ||
-        advocate?.yearsOfExperience?.includes(searchTerm)
-      );
-    });
-
-    setFilteredAdvocates(filteredAdvocates);
-  };
+  }, [data?.data?.value]);
 
   return (
     <div style={{ margin: "24px" }}>

--- a/src/components/AdvocatesTable/index.tsx
+++ b/src/components/AdvocatesTable/index.tsx
@@ -4,6 +4,7 @@ import { parse } from "path";
 import { useState, useEffect } from "react";
 import type { ChangeEvent } from "react";
 import { kebabCase } from "lodash";
+import AdvocatesSearch from "../AdvocatesSearch";
 
 export default function AdvocatesTable(data) {
   // console.log('In AdvocatesTable.tsx, this is data?.data: ', JSON.parse(data?.data?.value));
@@ -11,16 +12,6 @@ export default function AdvocatesTable(data) {
   console.log('In AdvocatesTable.tsx, this is advocates: ', advocates);
   const [filteredAdvocates, setFilteredAdvocates] = useState([]);
   const [searchTerm, setSearchTerm] = useState<string>("");
-
-  // useEffect(() => {
-  //   console.log("fetching advocates...");
-  //   fetch("/api/advocates").then((response) => {
-  //     response.json().then((jsonResponse) => {
-  //       setAdvocates(jsonResponse.data);
-  //       setFilteredAdvocates(jsonResponse.data);
-  //     });
-  //   });
-  // }, []);
 
   useEffect(() => {
     const parsedData = JSON.parse(data?.data?.value)?.data;
@@ -71,14 +62,7 @@ export default function AdvocatesTable(data) {
       <pre>
         {data?.data?.value}
       </pre>
-      <div>
-        <p>Search</p>
-        <p>
-          Searching for: <span id="search-term"></span>
-        </p>
-        <input style={{ border: "1px solid black" }} onChange={onChange} value={searchTerm} />
-        <button onClick={onClick}>Reset Search</button>
-      </div>
+      <AdvocatesSearch />
       <br />
       <br />
       <table>

--- a/src/components/AdvocatesTable/index.tsx
+++ b/src/components/AdvocatesTable/index.tsx
@@ -16,9 +16,6 @@ export default function AdvocatesTable(data) {
 
   return (
     <div style={{ margin: "24px" }}>
-      <pre>
-        {data?.data?.value}
-      </pre>
       <AdvocatesSearch />
       <br />
       <br />

--- a/src/utils/urlHelpers.ts
+++ b/src/utils/urlHelpers.ts
@@ -6,6 +6,7 @@ function objectToUrlParams(obj: urlParams) {
   const params = [];
 
   for (const key in obj) {
+    // @ts-expect-error
     params.push(`${encodeURIComponent(key)}=${encodeURIComponent(obj[key])}`);
   }
 

--- a/src/utils/urlHelpers.ts
+++ b/src/utils/urlHelpers.ts
@@ -1,0 +1,15 @@
+type urlParams = {
+  [key: string]: string | string[] | undefined;
+};
+
+function objectToUrlParams(obj: urlParams) {
+  const params = [];
+
+  for (const key in obj) {
+    params.push(`${encodeURIComponent(key)}=${encodeURIComponent(obj[key])}`);
+  }
+
+  return params.join('&');
+};
+
+export default objectToUrlParams;


### PR DESCRIPTION
The TLDR is that this PR sets up searching advocates by URL query params.

Listed out, this PR:
- Updates the Nextjs routes to handle query params.
- Adds a helper function to format query params together.